### PR TITLE
ci: test multiple Python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
+        python-version:
+          # adbc-driver-postgresql 1.6.0 supports Python 3.9.0 onwards
+          - "3.9.0"
+          - "3.10.0"
+          - "3.11.1"
+          - "3.12.0"
+          - "3.13.0"
         postgresql-version:
           # ROLLBACK AND CHAIN is used by ADBC but not supported until PostgreSQL 13.0
           - "13.0"
@@ -20,14 +27,15 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
 
-      - name: "Install Python"
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
 
       - name: "Install package and dependencies"
         run: |
-          pip install .[dev,ci]
+          uv pip install .[dev,ci]
 
       - name: "Start PostgreSQL"
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dev = [
 ci = [
     "pytest",
     "pytest-cov",
-    "sqlalchemy==2.0.7",
+    "sqlalchemy==2.0.7;python_version<'3.13'",
+    # SQLAlchemy doesn't support Python 3.13 until 2.0.31
+    "sqlalchemy==2.0.31;python_version>='3.13'",
     "adbc-driver-postgresql==1.6.0",
     "pyarrow==20.0.0",
 ]


### PR DESCRIPTION
Using uv to install specific version of Python because from experience it maintains support for older Python longer than GitHub's setup-python (because GitHub's setup-python essentially depends on ubuntu versions which periodically get removed