### PR TITLE
feat: tighten up SQLAlchemy minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ engine = sa.create_engine('postgresql+pgarrow://postgres:password@127.0.0.1:5432
 with engine.connect() as conn:
     results = conn.execute(sa.text("SELECT 1")).fetchall()
 ```
+
+
+## Compatibility
+
+- Python >= 3.9 (tested on 3.9.0, 3.10.0, 3.11.1, 3.12.0, and 3.13.0)
+- PostgreSQL >= 13.0 (tested on 13.0, 14.0, 15.0, and 16.0)
+- SQLAlchemy >= 2.0.7 on Python < 3.13, and SQLAlchemy >= 2.0.31 on Python >= 3.13 (tested on 2.0.7 on Python before 3.13.0, and SQLAlchemy 2.0.31 on Python 3.13.0)
+- PyArrow >= 20.0.0 (tested on 20.0.0)
+- adbc-driver-postgresql >= 1.6.0 (tested on 1.6.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
     "Topic :: Database",
 ]
 dependencies = [
-    "sqlalchemy>=2.0.7",
+    "sqlalchemy>=2.0.7;python_version<'3.13'",
+    "sqlalchemy>=2.0.31;python_version>='3.13'",
     "adbc-driver-postgresql>=1.6.0",
     "pyarrow>=20.0.0",
 ]


### PR DESCRIPTION
This tightens up the minimum SQLAlchemy version, and specifically making it clear that versions before 2.0.31 on Python 3.13 are not supported.

This also adds documentation to the README on what versions of PostgreSQL, Python, and various Python packages are supported.