### PR TITLE
fix: reflection when there are indexes on the table

### DIFF
--- a/test_pgarrow.py
+++ b/test_pgarrow.py
@@ -123,6 +123,7 @@ def test_reflection():
 
     with engine.connect() as conn:
         conn.execute(sa.text(f"CREATE TABLE {table_name} (id int)"))
+        conn.execute(sa.text(f"CREATE INDEX ON {table_name} (id)"))
         table = sa.Table(table_name, sa.MetaData(), schema="public", autoload_with=conn)
         assert table.name == table_name
         assert table.columns[0].name == 'id'


### PR DESCRIPTION
This works around the fact that ADBC returns results of int2vector fields as binary, at least in one case of relfection when there are indexes on the table.

(Also paranoia-tweaks a previous work around by only putting an `ord` on the expression that had it in the base query)